### PR TITLE
Fix: attempt to index field 'signalstrings' (a nil value)

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -180,7 +180,7 @@ local signalColorMap = {
 }
 
 local function RegisterStrings()
-  if remote.interfaces['signalstrings']['register_signal'] then
+  if remote.interfaces['signalstrings'] and remote.interfaces['signalstrings']['register_signal'] then
     local syms = {
       ["signal-stop"] = ".",
       ["signal-qmark"]="?",


### PR DESCRIPTION
`nixie-tubes` is currrently incorrectly checking for the presence of the `signalstrings` interface, causing the game to crash on load. This change corrects that.